### PR TITLE
Enable fat LTO for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 async-trait = "0.1"
 
-# Release with line-table debug info — needed by samply / perf to resolve
-# function names in the channel/connection hot path.
+# Release with fat LTO and line-table debug info — needed by samply / perf
+# to resolve function names in the channel/connection hot path.
 [profile.release]
 debug = "line-tables-only"
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
Measured for the MinGW Windows package:

- ntied.exe: 46,000,139 -> 23,698,311 bytes (-48.5%)

- ntied-server.exe: 6,095,703 -> 2,391,672 bytes (-60.8%)